### PR TITLE
Fixes

### DIFF
--- a/circle-cli.gemspec
+++ b/circle-cli.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   spec.add_dependency 'circleci'
-  spec.add_dependency 'rugged'
+  spec.add_dependency 'rugged', '>= 0.23.beta'
   spec.add_dependency 'octokit'
 
   spec.add_development_dependency 'bundler', '~> 1.5'

--- a/lib/circle/cli.rb
+++ b/lib/circle/cli.rb
@@ -84,7 +84,7 @@ module Circle
       if origin.url =~ %r{git@github.com:(\w+/\w+)\.git}
         $1
       else
-        raise "Unsupported repo url format #{origin.url.inpect}" # TODO: support other formats, mainly https
+        raise "Unsupported repo url format #{origin.url.inspect}" # TODO: support other formats, mainly https
       end
     end
 

--- a/lib/circle/cli.rb
+++ b/lib/circle/cli.rb
@@ -93,7 +93,7 @@ module Circle
     end
 
     def head
-      repository.head.target
+      repository.head.target_id
     end
 
     def repository

--- a/lib/circle/cli.rb
+++ b/lib/circle/cli.rb
@@ -37,10 +37,11 @@ module Circle
     def run_status
       unless last_status
         puts 'unknown'
-        exit(0)
+        exit(1)
       end
 
       puts last_status.state
+      exit(0)
     end
 
     def run_open


### PR DESCRIPTION
- Update rugged to be compatible with newer osx installs
- use rugged's new api to get head sha
- update status codes so that other programs can know when a branch is failing/passing
- fix typo that bombs app
