### PR TITLE
spring cleaning

### DIFF
--- a/circle-cli.gemspec
+++ b/circle-cli.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   spec.add_dependency 'circleci'
-  spec.add_dependency 'rugged'
+  spec.add_dependency 'rugged', '>= 0.23'
   spec.add_dependency 'octokit'
 
   spec.add_development_dependency 'bundler', '~> 1.5'

--- a/lib/circle/cli.rb
+++ b/lib/circle/cli.rb
@@ -96,7 +96,7 @@ module Circle
     end
 
     def head
-      repository.head.target
+      repository.head.target_id
     end
 
     def repository

--- a/lib/circle/cli.rb
+++ b/lib/circle/cli.rb
@@ -87,7 +87,7 @@ module Circle
       if origin.url =~ %r{git@github.com:(\w+/\w+)\.git}
         $1
       else
-        raise "Unsupported repo url format #{origin.url.inpect}" # TODO: support other formats, mainly https
+        raise "Unsupported repo url format #{origin.url.inspect}" # TODO: support other formats, mainly https
       end
     end
 

--- a/lib/circle/cli.rb
+++ b/lib/circle/cli.rb
@@ -35,12 +35,16 @@ module Circle
     end
 
     def run_status
-      unless last_status
-        puts 'unknown'
+      if last_status && last_status.state == 'success'
+        puts last_status.state
         exit(0)
+      elsif last_status
+        puts last_status.state
+      else
+        puts 'unknown'
       end
 
-      puts last_status.state
+      exit(1)
     end
 
     def run_open


### PR DESCRIPTION
circle-cli wasn't working for me on a newer mac osx install

This branch handles:
- update rugged to be compatible with newer osx installs
- update method for retrieving head sha to be compatible with newer rugged api
- fix typo that causes app to bomb if the app is using https
- update status codes so that external apps know if the branch is failing or passing
