### PR TITLE
Sets status to be default command if none given.

### DIFF
--- a/lib/circle/cli.rb
+++ b/lib/circle/cli.rb
@@ -25,6 +25,7 @@ module Circle
     def dispatch!(argv)
       @parser.parse!
       command, *args = argv
+      command = 'status' unless command
 
       method = "run_#{command.gsub('-', '_')}"
       if respond_to?(method)

--- a/lib/circle/cli/version.rb
+++ b/lib/circle/cli/version.rb
@@ -1,5 +1,5 @@
 module Circle
   class CLI
-    VERSION = '0.0.1'
+    VERSION = '0.0.2'
   end
 end


### PR DESCRIPTION
When a user runs `circle` by itself, this commit will make it so that
status is the default command.

Fixes #6
