### PR TITLE
Minor bugfixes

### DIFF
--- a/lib/circle/cli/project.rb
+++ b/lib/circle/cli/project.rb
@@ -33,7 +33,19 @@ module Circle
       end
 
       def request(klass, action, *args)
-        klass.send(action, repo.user_name, repo.project, *args).body
+        response = klass.send(action, repo.user_name, repo.project, *args)
+
+        if response.success?
+          response.body
+        else
+          $stderr.puts 'One or more errors occurred:'
+
+          response.errors.each do |error|
+            $stderr.puts "+ #{error.message}"
+          end
+
+          exit 1
+        end
       end
 
       private

--- a/lib/circle/cli/repo.rb
+++ b/lib/circle/cli/repo.rb
@@ -15,7 +15,7 @@ module Circle
       end
 
       def user_name
-        uri.path.split('/').first
+        uri.path[/^(\/?)(.+)\//, 2]
       end
 
       def project

--- a/lib/circle/cli/repo.rb
+++ b/lib/circle/cli/repo.rb
@@ -40,6 +40,9 @@ module Circle
 
       def repo
         @repo ||= Rugged::Repository.new(options[:repo])
+      rescue Rugged::RepositoryError
+        full_path = File.expand_path(options[:repo])
+        abort "#{full_path} is not a git repository."
       end
 
       def origin


### PR DESCRIPTION
- If the HTTP request isn't successful, show the errors.
- More intelligent parsing of repo urls. The leading `/` on the path of a git HTTP url was causing the app to explode.
- Emit an error when the user is not within a git repo
